### PR TITLE
Add option to disable output of seconds

### DIFF
--- a/README
+++ b/README
@@ -14,6 +14,11 @@ By default prints the date together with the time, but can be used for time only
 $("div#clock").clock({"calendar":"false"});
 
 
+By default, output includes seconds. If you would prefer to hide the seconds add the following option:
+
+$("div#clock").clock({"seconds":"false"});
+
+
 Includes 6 language translations for days of the week and months of the year: English, French, Spanish, Italian, German, Russian. 
 
 $("div#clock").clock({"langSet":"de"});

--- a/jqClock.js
+++ b/jqClock.js
@@ -74,6 +74,7 @@ $.fn.clock = function(options) {
     options.langSet = options.langSet || "en";
     options.format = options.format || ((options.langSet!="en") ? "24" : "12");
     options.calendar = options.calendar || "true";
+    options.seconds = options.seconds || "true";
 
     if (!$(this).hasClass("jqclock")){$(this).addClass("jqclock");}
 
@@ -119,7 +120,12 @@ $.fn.clock = function(options) {
             calend = "<span class='clockdate'>"+locale[myoptions.langSet].weekdays[dy]+', '+dt+' '+locale[myoptions.langSet].months[mo]+' '+y+"</span>";
           }
         }
-        $(el).html(calend+"<span class='clocktime'>"+h+":"+m+":"+s+ap+"</span>");
+        clockString = "<span class='clocktime'>"+h+":"+m;
+        if(options.seconds == "true") {
+          clockString = clockString+":"+s;
+        }
+        clockString = clockString+ap+"</span>";
+        $(el).html(calend+clockString);
         t[el_id] = setTimeout(function() { updateClock( $(el),myoptions ) }, 1000);
       }
 


### PR DESCRIPTION
I have added the option to disable the output of seconds.

Some people may not need to see seconds in their clock and there was now way to remove them as the script was. A good example of someone wanting to remove the seconds would be (this is why I needed it) if you had several clocks in a page with different timezones.
